### PR TITLE
feat: Add Vercel deployment configuration and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,29 @@ This project is composed by a [Node.js](https://www.google.com) app using [jsdom
 
 Initial Node app structure was inspired on [Wes Bos initial setup on the _Learn Node_ Course](https://github.com/wesbos/Learn-Node). Vynil record image from [CleanPNG](https://www.cleanpng.com/png-car-product-design-wheel-tire-dystopian-sebastian-6098663/)
 
+## Deployment to Vercel
+
+This project can be easily deployed using Vercel. Vercel is a cloud platform for static sites and Serverless Functions that enables developers to host websites and web services that deploy instantly, scale automatically, and require no supervision.
+
+Follow these steps to deploy the Random Album Cover Generator to Vercel:
+
+1.  **Sign up or Log in to Vercel:** Go to [https://vercel.com](https://vercel.com) and create an account or log in.
+2.  **Import Project:**
+    *   Click on "New Project".
+    *   Import the Git repository for this project (e.g., from GitHub, GitLab, Bitbucket).
+3.  **Configure Project (if necessary):**
+    *   Vercel will likely detect this as a Node.js project and configure settings automatically using the `vercel.json` file.
+    *   The `vercel.json` specifies `src/start.js` as the entry point and `yarn install && webpack` as the build command.
+    *   If manual configuration is needed, ensure the "Framework Preset" is set to "Node.js".
+    *   The "Build Command" might need to be set to `webpack` (Vercel often handles the `yarn install` part separately or as part of the preset).
+    *   The "Output Directory" can usually be left to its default unless your assets are built to a very specific non-standard location not covered by the framework.
+    *   The "Install Command" should be `yarn install`.
+4.  **Deploy:**
+    *   Click the "Deploy" button.
+    *   Vercel will build and deploy your application. You'll get a unique URL for your live site.
+
 ## Keywords:
-- jsdom 
+- jsdom
 - TravisCI
 - CI/CD
 - Async/Await

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "src/start.js",
+      "use": "@vercel/node",
+      "config": {
+        "buildCommand": "yarn install && webpack"
+      }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "src/start.js"
+    }
+  ]
+}


### PR DESCRIPTION
I've added a `vercel.json` file to configure your project for deployment on Vercel. The build process uses `yarn install && webpack` to prepare the application.

I've also updated `README.md` to include a new "Deployment to Vercel" section with step-by-step instructions on how to deploy the application. This includes connecting your Git repository to Vercel and relying on `vercel.json` for build configurations or manually setting them if needed.